### PR TITLE
Add team selection with color-coded participant cards

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,11 +32,14 @@ app.prepare().then(() => {
   }
 
   // 🔹 Adicionar participante a uma sessão
-  function addParticipant (sessionId, userId, userName, socketId) {
+  function addParticipant (sessionId, userId, userName, socketId, team = null) {
     const session = getOrCreateSession(sessionId);
     const existing = session.participants.find((p) => p.userId === userId);
     if (!existing) {
-      session.participants.push({ userId, userName, socketId, selectedCard: null });
+      session.participants.push({ userId, userName, socketId, selectedCard: null, team });
+    } else {
+      existing.team = team;
+      existing.socketId = socketId;
     }
   }
 
@@ -55,19 +58,19 @@ app.prepare().then(() => {
     });
 
     // 👥 Entrar na sala
-    socket.on("join_room", ({ sessionId, sessionName, userId, userName }) => {
-      console.log(`👤 ${userName} (${userId}) entrou na sala ${sessionId}`);
+    socket.on("join_room", ({ sessionId, sessionName, userId, userName, team }) => {
+      console.log(`👤 ${userName} (${userId}) [${team || 'no team'}] entrou na sala ${sessionId}`);
       socket.join(sessionId);
 
       const session = getOrCreateSession(sessionId, sessionName);
       if (
-        ["", null, undefined].includes(session.sessionName) 
+        ["", null, undefined].includes(session.sessionName)
       ) {
         socket.emit("redirect_to_home");
         return;
       }
 
-      addParticipant(sessionId, userId, userName, socket.id);
+      addParticipant(sessionId, userId, userName, socket.id, team);
 
       updateSession(sessionId);
     });

--- a/src/app/[sessionId]/join/page.tsx
+++ b/src/app/[sessionId]/join/page.tsx
@@ -7,11 +7,19 @@ import { useTranslation } from "react-i18next";
 import toast, { Toaster } from "react-hot-toast";
 import { useSession } from "@/components/useSession";
 
+const TEAMS = [
+  { value: "organizer", labelKey: "teamOrganizer", color: "bg-purple-500" },
+  { value: "dev", labelKey: "teamDev", color: "bg-blue-500" },
+  { value: "qa", labelKey: "teamQA", color: "bg-green-500" },
+  { value: "ux", labelKey: "teamUX", color: "bg-pink-500" },
+];
+
 export default function JoinSessionPage () {
   const router = useRouter();
   const { t } = useTranslation("common");
   const { sessionId } = useParams() as { sessionId: string };
   const [name, setName] = useState("");
+  const [team, setTeam] = useState("");
 
   const { sessionData } = useSession();
 
@@ -19,6 +27,9 @@ export default function JoinSessionPage () {
     const storedName = localStorage.getItem("pokerUserName");
     if (storedName)
       setName(storedName);
+    const storedTeam = localStorage.getItem("pokerUserTeam");
+    if (storedTeam)
+      setTeam(storedTeam);
   }, [sessionId]);
 
   function handleJoin (event: React.FormEvent) {
@@ -30,6 +41,9 @@ export default function JoinSessionPage () {
     }
 
     localStorage.setItem("pokerUserName", name.trim());
+    if (team) {
+      localStorage.setItem("pokerUserTeam", team);
+    }
     router.push(`/${sessionId}`);
   }
 
@@ -53,6 +67,27 @@ export default function JoinSessionPage () {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
+
+        <label className="block text-gray-700 font-medium mb-1 mt-4">{t("yourTeam")}</label>
+        <div className="relative">
+          <select
+            className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-700 text-lg shadow-sm appearance-none bg-white"
+            value={team}
+            onChange={(e) => setTeam(e.target.value)}
+          >
+            <option value="">{t("teamPlaceholder")}</option>
+            {TEAMS.map((t_item) => (
+              <option key={t_item.value} value={t_item.value}>
+                {t(t_item.labelKey)}
+              </option>
+            ))}
+          </select>
+          {team && (
+            <span
+              className={`absolute right-10 top-1/2 -translate-y-1/2 w-3 h-3 rounded-full ${TEAMS.find((t_item) => t_item.value === team)?.color}`}
+            />
+          )}
+        </div>
 
         <button
           type="submit"

--- a/src/components/ParticipantCard.tsx
+++ b/src/components/ParticipantCard.tsx
@@ -1,9 +1,51 @@
 "use client";
 
 import React from "react";
-import { Participant } from "./useSession";
+import { Participant, Team } from "./useSession";
 
+const TEAM_COLORS: Record<Team, { border: string; bg: string; bgRevealed: string; text: string; ring: string; nameText: string }> = {
+  organizer: {
+    border: "border-purple-400",
+    bg: "bg-purple-500",
+    bgRevealed: "bg-purple-400",
+    text: "text-purple-600",
+    ring: "ring-purple-300",
+    nameText: "text-purple-600",
+  },
+  dev: {
+    border: "border-blue-400",
+    bg: "bg-blue-500",
+    bgRevealed: "bg-blue-400",
+    text: "text-blue-600",
+    ring: "ring-blue-300",
+    nameText: "text-blue-600",
+  },
+  qa: {
+    border: "border-green-400",
+    bg: "bg-green-500",
+    bgRevealed: "bg-green-400",
+    text: "text-green-600",
+    ring: "ring-green-300",
+    nameText: "text-green-600",
+  },
+  ux: {
+    border: "border-pink-400",
+    bg: "bg-pink-500",
+    bgRevealed: "bg-pink-400",
+    text: "text-pink-600",
+    ring: "ring-pink-300",
+    nameText: "text-pink-600",
+  },
+};
 
+const DEFAULT_COLORS = {
+  border: "border-gray-400",
+  bg: "bg-gray-500",
+  bgRevealed: "bg-gray-400",
+  text: "text-gray-600",
+  ring: "ring-gray-300",
+  nameText: "text-gray-600",
+};
 
 interface ParticipantCardProps {
   participant: Participant;
@@ -15,20 +57,21 @@ export default function ParticipantCard ({
   isRevealed,
 }: ParticipantCardProps) {
 
+  const colors = participant.team ? TEAM_COLORS[participant.team] : DEFAULT_COLORS;
   const content = getCardContent();
   const style = getParticipantCardStyle();
 
   function getParticipantCardStyle () {
-    let style = "border border-blue-400 bg-white text-blue-600";
+    let style = `border ${colors.border} bg-white ${colors.text}`;
 
     if (participant.selectedCard) {
       style = isRevealed
-        ? "bg-blue-400 text-white border border-blue-400"
-        : "bg-blue-500 text-white border border-blue-500"
+        ? `${colors.bgRevealed} text-white border ${colors.border}`
+        : `${colors.bg} text-white border ${colors.bg}`
     }
 
     if (participant.isCurrentUser) {
-      style += " ring-4 ring-blue-300";
+      style += ` ring-4 ${colors.ring}`;
     }
 
     return style;
@@ -51,7 +94,7 @@ export default function ParticipantCard ({
       >
         {content}
       </div>
-      <span className={`mt-1  font-medium ${participant.isCurrentUser ? "text-blue-600 font-bold text-md" : "text-gray-800 text-sm"}`}>
+      <span className={`mt-1 font-medium ${participant.isCurrentUser ? `${colors.nameText} font-bold text-md` : "text-gray-800 text-sm"}`}>
         {participant.userName}
       </span>
     </div>

--- a/src/components/useSession.ts
+++ b/src/components/useSession.ts
@@ -3,9 +3,12 @@ import { useParams, useRouter } from "next/navigation";
 import { v4 as uuidv4 } from "uuid";
 import { io, Socket } from "socket.io-client";
 
+export type Team = "organizer" | "dev" | "qa" | "ux";
+
 export interface Participant {
   userId: string;
   userName: string;
+  team: Team | null;
   isCurrentUser: boolean;
   selectedCard: string | null;
 }
@@ -45,6 +48,7 @@ export function useSession () {
 
     const storedUserId = getOrCreateUserId();
     const storedUserName = getStoredUserName();
+    const storedUserTeam = getStoredUserTeam();
 
     if (!storedUserName) {
       router.push(`/${sessionId}/join`);
@@ -56,7 +60,7 @@ export function useSession () {
     generateInviteLink();
 
     // Certifique-se de que a função de cleanup é sempre retornada
-    const cleanup = initializeSocketConnection(storedUserId, storedUserName);
+    const cleanup = initializeSocketConnection(storedUserId, storedUserName, storedUserTeam);
     return cleanup || (() => { });
   }, [sessionId, router]);
 
@@ -76,12 +80,17 @@ export function useSession () {
     return localStorage.getItem("pokerUserName");
   }
 
+  /** 🔹 Obtém o time do usuário armazenado */
+  function getStoredUserTeam (): Team | null {
+    return localStorage.getItem("pokerUserTeam") as Team | null;
+  }
+
   /** 🔹 Inicializa a conexão com o WebSocket */
-  function initializeSocketConnection (storedUserId: string, storedUserName: string): () => void {
+  function initializeSocketConnection (storedUserId: string, storedUserName: string, storedUserTeam: Team | null): () => void {
     socketRef.current = io(HOST);
     const socket = socketRef.current;
 
-    socket.emit("join_room", { sessionId, userId: storedUserId, userName: storedUserName });
+    socket.emit("join_room", { sessionId, userId: storedUserId, userName: storedUserName, team: storedUserTeam });
 
     socket.on("session_update", (data: SessionState) => updateSessionData(data, storedUserId));
     socket.on("flip_cards", startCountdownBeforeReveal);

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -5,7 +5,7 @@ export function ensureLocalUser (participants: Participant[], localUserId: strin
   if (!exists && localUserId && localUserName) {
     return [
       ...participants,
-      { userId: localUserId, userName: localUserName, selectedCard: null, isCurrentUser: true },
+      { userId: localUserId, userName: localUserName, selectedCard: null, isCurrentUser: true, team: null },
     ];
   }
   return participants;

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -25,5 +25,11 @@
   "yourName": "Your Name",
   "namePlaceholder": "Enter your name...",
   "enterSession": "Enter Session",
-  "errorEnterName": "Please enter your name!"
+  "errorEnterName": "Please enter your name!",
+  "yourTeam": "Your Team",
+  "teamPlaceholder": "Select your team...",
+  "teamOrganizer": "Organizer",
+  "teamDev": "Dev",
+  "teamQA": "QA",
+  "teamUX": "UX"
 }

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -25,5 +25,11 @@
   "yourName": "Seu Nome",
   "namePlaceholder": "Digite seu nome...",
   "enterSession": "Entrar na Sessão",
-  "errorEnterName": "Por favor, insira seu nome!"
+  "errorEnterName": "Por favor, insira seu nome!",
+  "yourTeam": "Seu Time",
+  "teamPlaceholder": "Selecione seu time...",
+  "teamOrganizer": "Organizador",
+  "teamDev": "Dev",
+  "teamQA": "QA",
+  "teamUX": "UX"
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,12 @@ module.exports = {
     "./src/pages/**/*.{js,ts,jsx,tsx}",
     "./src/components/**/*.{js,ts,jsx,tsx}",
   ],
+  safelist: [
+    "bg-purple-500",
+    "bg-blue-500",
+    "bg-green-500",
+    "bg-pink-500",
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- Added a team selection dropdown (Organizer, Dev, QA, UX) on the join page, allowing participants to identify themselves by team
- Each team is assigned a distinct color (purple, blue, green, pink) that is displayed on their voting card throughout the session
- Participants without a team are shown in gray
- Team selection is persisted in localStorage and transmitted via WebSocket

## Motivation
During planning poker sessions with cross-functional teams, it can be difficult to distinguish which votes came from which team. By color-coding participant cards by team, it becomes visually easy to spot voting patterns and group consensus at a glance — for example, identifying whether devs and QAs are aligned or diverging on estimates.

## Changes
- `src/app/[sessionId]/join/page.tsx` — Team dropdown with color indicator
- `src/components/ParticipantCard.tsx` — Dynamic card colors per team
- `src/components/useSession.ts` — `Team` type and team propagation via WebSocket
- `server.js` — Store and broadcast team data per participant
- `src/i18n/locales/{en,pt}/common.json` — i18n keys for team labels
- `tailwind.config.js` / `src/components/utils.ts` — Safelist and type adjustments

## Test plan
- [ ] Create a session and join selecting each team — verify the card color matches
- [ ] Join without selecting a team — verify the card appears in gray
- [ ] Flip cards and confirm team colors persist on revealed state
- [ ] Rejoin the same session — verify team selection is restored from localStorage
- [ ] Test with multiple participants on different teams to validate visual distinction
